### PR TITLE
Append GitHub Actions run ID as a suffix to the package.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Restore
       run: dotnet restore src/Consolpunke
     - name: Build
-      run: dotnet build src/Consolpunke --configuration Release --no-restore
+      run: dotnet build src/Consolpunke --configuration Release --no-restore /p:VersionSuffix=build.$GITHUB_RUN_ID
     - name: Test
       run: dotnet test src/Consolpunke.Tests --configuration Release


### PR DESCRIPTION
This PR sets up the GitHub build action to append the run ID as a suffix to the NuGet package which is produced.