### PR TITLE
Tweak build to run Consolpunke to print out version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,5 +19,9 @@ jobs:
       run: dotnet restore src/Consolpunke
     - name: Build
       run: dotnet build src/Consolpunke --configuration Release --no-restore /p:VersionSuffix=build.$GITHUB_RUN_ID
-    - name: Test
+    - name: Unit Test
       run: dotnet test src/Consolpunke.Tests --configuration Release
+    - name: Smoke Test
+      run: |
+        dotnet tool install -g Consolpunke -add-source bin/Release
+        consolpunke --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
       run: dotnet test src/Consolpunke.Tests --configuration Release
     - name: Smoke Test
       run: |
-        dotnet tool install -g Consolpunke -add-source bin/Release
+        dotnet tool install -g Consolpunke -add-source bin/Release --version 1.0.0-build.$GITHUB_RUN_ID
         consolpunke --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
       run: dotnet test src/Consolpunke.Tests --configuration Release
     - name: Smoke Test
       run: |
-        dotnet tool install -g Consolpunke -add-source bin/Release --version 1.0.0-build.$GITHUB_RUN_ID
+        dotnet tool install -g Consolpunke --add-source bin/Release --version 1.0.0-build.$GITHUB_RUN_ID
         consolpunke --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
       run: dotnet test src/Consolpunke.Tests --configuration Release
     - name: Smoke Test
       run: |
-        dotnet tool install -g Consolpunke --add-source bin/Release --version 1.0.0-build.$GITHUB_RUN_ID
+        dotnet tool install -g Consolpunke --add-source src/Consolpunke/bin/Release --version 1.0.0-build.$GITHUB_RUN_ID
         consolpunke --version


### PR DESCRIPTION
This PR appends a smoke test step to the build which installs Consolpunke and attempts to print out the version. Version printing isn't implemented yet but will be soon and I'll start adding more elaborate smoke tests.